### PR TITLE
Ignore the Dist::Zilla .build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 App-ConsistentRandomPassword-*
+.build/


### PR DESCRIPTION
This way the working dir is nice and clean and one isn't distracted by
the creation of automatically generated directories.